### PR TITLE
bump ibm-fhir-server from 4.11.0 to 4.11.1

### DIFF
--- a/data-access/docker-compose.yaml
+++ b/data-access/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   fhir-server:
-    image: ibmcom/ibm-fhir-server:4.11.0
+    image: ibmcom/ibm-fhir-server:4.11.1
     hostname: fhir
     volumes:
       - type: bind
@@ -35,7 +35,7 @@ services:
     networks:
       - fhir
   keycloak:
-    image: quay.io/alvearie/smart-keycloak:0.4.1
+    image: quay.io/alvearie/smart-keycloak:0.5.1
     hostname: keycloak
     environment:
       - KEYCLOAK_USER=admin

--- a/data-access/pom.xml
+++ b/data-access/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<fhir.version>4.11.0</fhir.version>
+		<fhir.version>4.11.1</fhir.version>
 	</properties>
 
 	<build>

--- a/services/ibm-fhir-server/data-access/README.md
+++ b/services/ibm-fhir-server/data-access/README.md
@@ -5,5 +5,5 @@ This directory contains a docker image that extends the IBM FHIR Server for use 
 # Bill of materials
 
 * IBM FHIR Server
-* fhir-smart and its transitive dependencies
+* fhir-smart
 * fhir-ig-us-core


### PR DESCRIPTION
Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>